### PR TITLE
Debugged my solution

### DIFF
--- a/script/main.js
+++ b/script/main.js
@@ -48,7 +48,8 @@
 
 	function allowDragOver(event) {
 		//Allow the puzzle piece to be dropped only if there is no other piece in the drop zone.
-		if (event.path[0].classList[0]==='drop-zone'){
+
+		if (event.path[0].classList[0]==='drop-zone' && event.path[0].children.length===0){
 			event.preventDefault();
 		}
 	}


### PR DESCRIPTION
Found another bug with my method of debugging. A tiny area around the puzzle picture allowed user to still drop multiple puzzle pieces. So I'm now double-checking if my dropzone doesn't have any children.